### PR TITLE
Minimise conflict with other gimbal-effecting mods

### DIFF
--- a/Plugin/GimbalRotation.cs
+++ b/Plugin/GimbalRotation.cs
@@ -74,7 +74,7 @@ namespace RCSBuildAid
 
         void Update ()
         {
-            if (gimbal == null || (Time.time - startTime) * speed > 2) {
+            if (gimbal == null || (RCSBuildAid.Direction == Direction.none && (Time.time - startTime) * speed > 2)) {
                 return;
             }
             for (int i = 0; i < gimbal.gimbalTransforms.Count; i++) {

--- a/Plugin/GimbalRotation.cs
+++ b/Plugin/GimbalRotation.cs
@@ -74,7 +74,7 @@ namespace RCSBuildAid
 
         void Update ()
         {
-            if (gimbal == null || (Time.time - startTime) * speed >= 1) {
+            if (gimbal == null || (Time.time - startTime) * speed > 2) {
                 return;
             }
             for (int i = 0; i < gimbal.gimbalTransforms.Count; i++) {

--- a/Plugin/GimbalRotation.cs
+++ b/Plugin/GimbalRotation.cs
@@ -74,7 +74,7 @@ namespace RCSBuildAid
 
         void Update ()
         {
-            if (gimbal == null) {
+            if (gimbal == null || (Time.time - startTime) * speed >= 1) {
                 return;
             }
             for (int i = 0; i < gimbal.gimbalTransforms.Count; i++) {


### PR DESCRIPTION
Forcing gimbal rotation on every Update() conflicts with other mods that also set gimbal rotations.
This change stops forcing gimbal rotation if 'None' rotation is selected in the RCSBuildAid GUI, but leaves sufficient time for gimbals to be interpolated to the desired None position.

Tested in isolation and alongside TweakableGimbal.

Open to suggestions for improvements.